### PR TITLE
Realization Refactor

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -40,6 +40,8 @@ class Game
 	
 	Step(move)
 	{
+		console.log("Game.Step(move) fired!");
+		
 		if (this.gameState === 0)
 		{
 			this.DoTurn(move);
@@ -51,20 +53,6 @@ class Game
 		}
 	}
 
-	
-	Step()
-	{
-		if (this.gameState === 0)
-		{
-			this.DoTurn();
-			this.CheckGameEnd();
-		}
-		if (this.gameState !== 0)
-		{
-			document.getElementById("message").innerHTML = "The game is now over!";
-		}
-	}
-	
 	DoTurn(move)
 	{
 		if (!this.nextTurn.Validate(move))
@@ -77,34 +65,6 @@ class Game
 			document.getElementById("message").innerHTML = "Illegal move.";
 			return;
 		}
-		
-		/* Make the move */
-		this.CommitMove(proposedMove);
-		
-		/* Get the next move */
-		this.lastTurn = this.nextTurn;
-		this.nextTurn = this.nextTurn.EndTurn();
-		if (this.nextTurn === undefined)
-		{
-			this.turnIndex = (this.turnIndex + 1) % this.turnOrder.length;
-			this.nextTurn = this.turnOrder[this.turnIndex];
-		}
-		
-		/* Update the vizualization */
-		realizer.Update();
-	}
-	
-	DoTurn()
-	{
-		/* Get a legal move */
-		let proposedMove = this.nextTurn.GetMove();
-		while (!this.Validate(proposedMove))
-		{
-			console.log("Game invalidated the move.");
-			document.getElementById("message").innerHTML = "Illegal move.";
-			proposedMove = this.nextTurn.GetMove();
-		}
-		document.getElementById("message").innerHTML = "";
 		
 		/* Make the move */
 		this.CommitMove(proposedMove);

--- a/src/Game.js
+++ b/src/Game.js
@@ -37,6 +37,19 @@ class Game
 		this.realizer = realizer;
 		this.players.forEach((player) => {player.realizer = realizer; });
 	}
+	
+	Step(move)
+	{
+		if (this.gameState === 0)
+		{
+			this.DoTurn(move);
+			this.CheckGameEnd();
+		}
+		if (this.gameState !== 0)
+		{
+			document.getElementById("message").innerHTML = "The game is now over!";
+		}
+	}
 
 	
 	Step()
@@ -50,6 +63,35 @@ class Game
 		{
 			document.getElementById("message").innerHTML = "The game is now over!";
 		}
+	}
+	
+	DoTurn(move)
+	{
+		if (!this.nextTurn.Validate(move))
+		{
+			return;
+		}
+		if (!this.Validate(move))
+		{
+			console.log("Game invalidated the move.");
+			document.getElementById("message").innerHTML = "Illegal move.";
+			return;
+		}
+		
+		/* Make the move */
+		this.CommitMove(proposedMove);
+		
+		/* Get the next move */
+		this.lastTurn = this.nextTurn;
+		this.nextTurn = this.nextTurn.EndTurn();
+		if (this.nextTurn === undefined)
+		{
+			this.turnIndex = (this.turnIndex + 1) % this.turnOrder.length;
+			this.nextTurn = this.turnOrder[this.turnIndex];
+		}
+		
+		/* Update the vizualization */
+		realizer.Update();
 	}
 	
 	DoTurn()

--- a/src/Game.js
+++ b/src/Game.js
@@ -6,7 +6,6 @@ class Game
 		this.board = board;
 		this.players = players;
 		this.endConditions = endConditions;
-		this.realizer = undefined; /* Has to be added later */
 		
 		/* Default turn order is alternating, any legal move goes */
 		const legalActions = {};
@@ -32,16 +31,8 @@ class Game
 		this.gameState = 0;
 	}
 	
-	SetRealizer(realizer)
-	{
-		this.realizer = realizer;
-		this.players.forEach((player) => {player.realizer = realizer; });
-	}
-	
 	Step(move)
 	{
-		console.log("Game.Step(move) fired!");
-		
 		if (this.gameState === 0)
 		{
 			this.DoTurn(move);
@@ -67,7 +58,7 @@ class Game
 		}
 		
 		/* Make the move */
-		this.CommitMove(proposedMove);
+		this.CommitMove(move);
 		
 		/* Get the next move */
 		this.lastTurn = this.nextTurn;
@@ -77,9 +68,6 @@ class Game
 			this.turnIndex = (this.turnIndex + 1) % this.turnOrder.length;
 			this.nextTurn = this.turnOrder[this.turnIndex];
 		}
-		
-		/* Update the vizualization */
-		realizer.Update();
 	}
 	
 	CheckGameEnd()

--- a/src/Player.js
+++ b/src/Player.js
@@ -19,10 +19,4 @@ class Player
 		this.color = color;
 		this.realizer = undefined;
 	}
-	
-	GetMove()
-	{
-		const move = this.realizer.GetMove();
-		return move;
-	}
 }

--- a/src/Player.js
+++ b/src/Player.js
@@ -17,6 +17,5 @@ class Player
 		this.dropablePieces = dropablePieces;
 		this.capturedPieces = capturedPieces;
 		this.color = color;
-		this.realizer = undefined;
 	}
 }

--- a/src/Realizer.js
+++ b/src/Realizer.js
@@ -7,7 +7,6 @@ class Realizer
 		this.board = game.board;
 		this.isFullyUpdated = false;
 		this.moveQueue = [];
-		this.moveQueueMutex = false;
 		
 		this.cellsPerRow = Math.round(Math.sqrt(this.board.contents.length));
 		
@@ -48,10 +47,7 @@ class Realizer
 	
 	GetMove()
 	{
-		while (this.moveQueueMutex);
-		this.moveQueueMutex = true;
 		const move = this.moveQueue.shift();
-		this.moveQueueMutex = false;
 		return move;
 	}
 	
@@ -65,13 +61,10 @@ class Realizer
 		moveObject.target = Number(move.trim().match(/\d+$/));
 		
 		/* Load move */
-		while (this.moveQueueMutex);
-		this.moveQueueMutex = true;
 		this.moveQueue.push(moveObject);
-		this.moveQueueMutex = false;
 		
 		/* Fire up the game engine */
-		this.game.Step();
+		this.game.Step(moveObject);
 	}
 	
 	CreateDisplayBoard()

--- a/src/Realizer.js
+++ b/src/Realizer.js
@@ -14,16 +14,15 @@ class Realizer
 	}
 	
 	/**
-	 * Method to be called by the front-end. Can be called multiple
-	 * times without incurring computational cost if no update is
-	 * available. Outputs the current state of the board.
+	 * Method to be called by the front-end. Incurs computational
+	 * cost each time called. Outputs the current state of the board.
 	 */
 	Realize()
 	{
-		if (this.isFullyUpdated)
-		{
-			return;
-		}
+		/* Update the board */
+		this.displayBoard = this.CreateDisplayBoard();
+		
+		/* Display it */
 		let outputArea = document.getElementById("output");
 		if (outputArea.firstChild)
 		{
@@ -33,28 +32,8 @@ class Realizer
 		this.isFullyUpdated = true;
 	}
 	
-	/**
-	 * Causes the realizer to update its representation of the
-	 * stored board. Should be called by the back-end. Incurs
-	 * computational cost each time it is run.
-	 */
-	Update()
-	{
-		// Keep track of what we are supposed to display
-		this.displayBoard = this.CreateDisplayBoard();
-		this.isFullyUpdated = false;
-	}
-	
-	GetMove()
-	{
-		const move = this.moveQueue.shift();
-		return move;
-	}
-	
 	InputMove(move)
 	{
-		console.log("Realizer.InputMove fired!");
-		
 		/* Parse move into object */
 		const moveObject = {};
 		moveObject.move = move.includes("->");

--- a/src/Realizer.js
+++ b/src/Realizer.js
@@ -53,6 +53,8 @@ class Realizer
 	
 	InputMove(move)
 	{
+		console.log("Realizer.InputMove fired!");
+		
 		/* Parse move into object */
 		const moveObject = {};
 		moveObject.move = move.includes("->");

--- a/src/Realizer.js
+++ b/src/Realizer.js
@@ -9,8 +9,6 @@ class Realizer
 		this.moveQueue = [];
 		
 		this.cellsPerRow = Math.round(Math.sqrt(this.board.contents.length));
-		
-		this.displayBoard = this.CreateDisplayBoard();
 	}
 	
 	/**
@@ -19,16 +17,12 @@ class Realizer
 	 */
 	Realize()
 	{
-		/* Update the board */
-		this.displayBoard = this.CreateDisplayBoard();
-		
-		/* Display it */
 		let outputArea = document.getElementById("output");
 		if (outputArea.firstChild)
 		{
 			outputArea.removeChild(outputArea.firstChild);
 		}
-		outputArea.appendChild(this.displayBoard);
+		outputArea.appendChild(this.CreateDisplayBoard());
 		this.isFullyUpdated = true;
 	}
 	

--- a/src/Turn.js
+++ b/src/Turn.js
@@ -16,18 +16,6 @@ class Turn
 		this.legalActions = legalActions;
 	}
 	
-	GetMove()
-	{
-		let move = undefined;
-		let approved = false;		
-		while (!approved)
-		{
-			move = this.player.GetMove();
-			approved = this.Validate(move);
-		}
-		return move;
-	}
-	
 	Validate(move)
 	{
 		let approved = true;

--- a/src/Turn.js
+++ b/src/Turn.js
@@ -23,35 +23,42 @@ class Turn
 		while (!approved)
 		{
 			move = this.player.GetMove();
-			approved = true;
-			if (this.legalActions.piece !== undefined)
-			{
-				// TODO: Dark magic to validate it's the right piece
-			}
-			if (this.board.contents[move.source].player !== this.player)
-			{
-				document.getElementById("message").innerHTML = "Invalid action: tried to move the opponent's piece.";
-				approved = false;
-				throw "Tried to move the enemy's piece.";
-			}
-			if (move.move && !this.legalActions.move)
-			{
-				document.getElementById("message").innerHTML = "Invalid action: must not move.";
-				approved = false;
-				throw "Tried to move when move disallowed.";
-			}
-			if (move.capture && !this.legalActions.capture)
-			{
-				document.getElementById("message").innerHTML = "Invalid action: must not capture.";
-				approved = false;
-				throw "Tried to capture when capture disallowed.";
-			}
-			if (!approved)
-			{
-				console.log("Did not approve!");
-			}
+			approved = this.Validate(move);
 		}
 		return move;
+	}
+	
+	Validate(move)
+	{
+		let approved = true;
+		if (this.legalActions.piece !== undefined)
+		{
+			// TODO: Dark magic to validate it's the right piece
+		}
+		if (this.board.contents[move.source].player !== this.player)
+		{
+			document.getElementById("message").innerHTML = "Invalid action: tried to move the opponent's piece.";
+			approved = false;
+			throw "Tried to move the enemy's piece.";
+		}
+		if (move.move && !this.legalActions.move)
+		{
+			document.getElementById("message").innerHTML = "Invalid action: must not move.";
+			approved = false;
+			throw "Tried to move when move disallowed.";
+		}
+		if (move.capture && !this.legalActions.capture)
+		{
+			document.getElementById("message").innerHTML = "Invalid action: must not capture.";
+			approved = false;
+			throw "Tried to capture when capture disallowed.";
+		}
+		if (!approved)
+		{
+			console.log("Did not approve!");
+		}
+		
+		return approved;
 	}
 	
 	/**

--- a/src/main.js
+++ b/src/main.js
@@ -7,8 +7,6 @@ async function startGame()
 	
 	realizer = new Realizer(game);
 	
-	game.SetRealizer(realizer);
-	
 	setInterval(() => {realizer.Realize();}, 500);
 }
 


### PR DESCRIPTION
Refactors the Engine section of the architecture to remove all references to Realizer. Changes some functionality so that Realizer always tries to update the board, and so Realizer pushes moves into Game.

In essence, Realizer should now be its own layer between the Engine and the user. Realizer's only access point to the Engine should be through Game. 

This PR will cause some current test PRs (#20) to fail - those will be fixed later. It will be marked as a blocker for future testing tasks whose behavior it changes (#17, #21, #22).