### PR TITLE
Add support for initial flag

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -1,7 +1,7 @@
 /* Represents a component of a vector */
 class Component
 {
-    constructor(length, maxRep, jump, hop, promote)
+    constructor(length, maxRep, jump, hop, promote, initial)
     {
         this.length = length;
         /* Slight efficiency, clean output while debugging */
@@ -9,11 +9,12 @@ class Component
         this.jump = jump;
         this.hop = hop;
         this.promote = promote;
+        this.initial = initial;
     }
 
     static DeepCopy(component)
     {
-        return new Component(component.length, component.maxRep, component.jump, component.hop, component.promote);
+        return new Component(component.length, component.maxRep, component.jump, component.hop, component.promote, component.initial);
     }
 
     toString()
@@ -30,7 +31,8 @@ class Component
             1,
             localFlags.includes("j") || globalFlags.includes("j"),
             localFlags.includes("h") || globalFlags.includes("h"),
-            localFlags.includes("p") || globalFlags.includes("p")
+            localFlags.includes("p") || globalFlags.includes("p"),
+            localFlags.includes("i") || globalFlags.includes("i")
         );
 
         const globalFiniteRepetition = globalFlags.match(/{(\d+)}/);
@@ -72,7 +74,7 @@ class Component
             component.maxRep = 1;
         }
 
-        const reversedComponent = new Component(-component.length, component.maxRep, component.jump, component.hop, component.promote);
+        const reversedComponent = new Component(-component.length, component.maxRep, component.jump, component.hop, component.promote, component.initial);
         return localFlags.includes("d") || globalFlags.includes("d") || component.length === 0 ? [component] : [component, reversedComponent];
     }
 }

--- a/src/Game.js
+++ b/src/Game.js
@@ -154,6 +154,7 @@ class Game
             this.board.contents[move.targetLocation] = this.board.contents[move.srcLocation];
             this.board.contents[move.srcLocation] = undefined;
         }
+        this.board.contents[move.targetLocation].setMoves(1);
         this.moveStack.push(move);
         if (realizer)
         {
@@ -184,6 +185,8 @@ class Game
         }
         this.redoStack.push(moveToUndo);
         this.UpdateUndoRedoVisibility();
+
+        this.board.contents[moveToUndo.srcLocation].setMoves(-1);
 
         this.turnIndex = (this.turnIndex - 1 + this.turnOrder.length) % this.turnOrder.length;
         this.nextTurn = this.turnOrder[this.turnIndex];

--- a/src/Piece.js
+++ b/src/Piece.js
@@ -9,6 +9,12 @@ class Piece
         this.identifier = "";
         this.value = 1;
         this.player = undefined;
+
+        /* For distinguishing first-move actions */
+        this.moves = 0;
+        this.initialMoveVectors = [];
+        this.initialCaptureVectors = [];
+        this.initialMoveCaptureVectors = [];
     }
 
     static Create(baseObj)
@@ -44,18 +50,33 @@ class Piece
     setMoveVectors(moveVectors)
     {
         this.moveVectors = moveVectors;
+        this.initialMoveVectors = this.moveVectors.filter((vector) => {
+            return vector.components.reduce((initial, component) => {
+                return initial || component.initial;
+            }, false);
+        });
         return this;
     }
 
     setCaptureVectors(captureVectors)
     {
         this.captureVectors = captureVectors;
+        this.initialCaptureVectors = this.captureVectors.filter((vector) => {
+            return vector.components.reduce((initial, component) => {
+                return initial || component.initial;
+            }, false);
+        });
         return this;
     }
 
     setMoveCaptureVectors(moveCaptureVectors)
     {
         this.moveCaptureVectors = moveCaptureVectors;
+        this.initialMoveCaptureVectors = this.moveCaptureVectors.filter((vector) => {
+            return vector.components.reduce((initial, component) => {
+                return initial || component.initial;
+            }, false);
+        });
         return this;
     }
 
@@ -75,5 +96,27 @@ class Piece
     {
         this.value = value;
         return this;
+    }
+
+    setMoves(delta)
+    {
+        const noPriorMove = this.moves === 0;
+        this.moves += delta;
+
+        /* If first move, remove initial vectors */
+        if (this.moves > 0 && noPriorMove)
+        {
+            this.moveVectors = this.moveVectors.filter((vector) => !this.initialMoveVectors.includes(vector));
+            this.captureVectors = this.captureVectors.filter((vector) => !this.initialCaptureVectors.includes(vector));
+            this.moveCaptureVectors = this.moveCaptureVectors.filter((vector) => !this.initialMoveCaptureVectors.includes(vector));
+        }
+
+        /* If undoing first move, restore initial vectors */
+        if (!noPriorMove && this.moves === 0)
+        {
+            this.moveVectors = this.moveVectors.concat(this.initialMoveVectors);
+            this.captureVectors = this.moveVectors.concat(this.initialCaptureVectors);
+            this.moveCaptureVectors = this.moveVectors.concat(this.initialMoveCaptureVectors);
+        }
     }
 }

--- a/src/Piece.js
+++ b/src/Piece.js
@@ -115,8 +115,8 @@ class Piece
         if (!noPriorMove && this.moves === 0)
         {
             this.moveVectors = this.moveVectors.concat(this.initialMoveVectors);
-            this.captureVectors = this.moveVectors.concat(this.initialCaptureVectors);
-            this.moveCaptureVectors = this.moveVectors.concat(this.initialMoveCaptureVectors);
+            this.captureVectors = this.captureVectors.concat(this.initialCaptureVectors);
+            this.moveCaptureVectors = this.moveCaptureVectors.concat(this.initialMoveCaptureVectors);
         }
     }
 }

--- a/src/Vector.js
+++ b/src/Vector.js
@@ -33,7 +33,7 @@ class Vector
                 return;
             }
 
-            const checkValid = vectorString.match(/\((\ *-?\d+[\d{}+jhd]*\ *,)+\ *-?\d+[\d{}+jhd]*\ *\)[\d{}+jhd]*/g);
+            const checkValid = vectorString.match(/\((\ *-?\d+[\d{}+jhdi]*\ *,)+\ *-?\d+[\d{}+jhdi]*\ *\)[\d{}+jhdi]*/g);
             if (checkValid === null || checkValid.length <= 0)
             {
                 console.error(`Improperly formatted vector: ${vectorString}`);

--- a/src/config/Chess.json
+++ b/src/config/Chess.json
@@ -4,7 +4,7 @@
         "adjacencyMatrix": null
     },
     "pieces": [{
-            "move": "(0, 1d)",
+            "move": "(0, 1d); (0, 2di)",
             "capture": "",
             "moveCapture": "(1, 1d)",
             "identifier": "p"

--- a/src/config/preloaded/2PChess.js
+++ b/src/config/preloaded/2PChess.js
@@ -4,7 +4,7 @@ const config = {
         adjacencyMatrix: null
     },
     pieces: [{
-            move: "(0, 1d)",
+            move: "(0, 1d); (0, 2di)",
             capture: "",
             moveCapture: "(1, 1d)",
             identifier: "p"

--- a/src/config/preloaded/2POmegaChess.js
+++ b/src/config/preloaded/2POmegaChess.js
@@ -148,7 +148,7 @@ const config = {
             [131,-132,null,-143,144,null,null,null,null]]
     },
     pieces: [{
-            move: "(0, 1d)",
+            move: "(0, 1d); (0, 1{3}di)",
             capture: "",
             moveCapture: "(1, 1d)",
             identifier: "p"

--- a/src/config/preloaded/PvCPUChess.js
+++ b/src/config/preloaded/PvCPUChess.js
@@ -4,7 +4,7 @@ const config = {
         adjacencyMatrix: null
     },
     pieces: [{
-            move: "(0, 1d)",
+            move: "(0, 1d); (0, 2di)",
             capture: "",
             moveCapture: "(1, 1d)",
             "value": 1,

--- a/src/config/preloaded/PvCPUOmegaChess.js
+++ b/src/config/preloaded/PvCPUOmegaChess.js
@@ -148,7 +148,7 @@ const config = {
             [131,-132,null,-143,144,null,null,null,null]]
     },
     pieces: [{
-            move: "(0, 1d)",
+            move: "(0, 1d); (0, 1{3}di)",
             capture: "",
             moveCapture: "(1, 1d)",
             value: 1,


### PR DESCRIPTION
Allows pieces to move differently on the first turn than on later turns.

Probably could be expanded to allow different actions based on how many times the piece has moved, but I would rather do that in a superior fashion to this.